### PR TITLE
Added Body.Close to get getObject

### DIFF
--- a/locustfiles/go/locust-s3/main.go
+++ b/locustfiles/go/locust-s3/main.go
@@ -147,6 +147,7 @@ func getObject() {
 		if config.Verbose {
 			fmt.Printf("get object %s/%s\n", obj.ObjectBucket, obj.ObjectKey)
 		}
+		resp.Body.Close()
 	}
 	obj.ReleaseObject(err)
 }


### PR DESCRIPTION
fixes leaking file descriptors