### PR TITLE
Added delay after delete operation

### DIFF
--- a/locustfiles/go/locust-s3/main.go
+++ b/locustfiles/go/locust-s3/main.go
@@ -192,6 +192,7 @@ func deleteObject() {
 		time.Sleep(1000 * time.Millisecond)
 		return
 	}
+	time.Sleep(25 * time.Millisecond)
 
 	start := time.Now().UnixNano() / config.LoadConf.Locust.TimeResolution
 	_, err := svc.DeleteObject(&s3.DeleteObjectInput{


### PR DESCRIPTION
While running large scale testing we noticed that the same redis random object was being picked for both DELETE and GET. When the DELETE finished first the GET would generate a failure message.  Through trial-and-error by injected a 25 millisecond delay into the DELETE function seemed to eliminate the failures.  With a 20 ms delay we still see ~3% failures. Unfortunately this delay is also reflected in the RPS and response time measurements.