### PR TITLE
Add configurable delay for deletes

### DIFF
--- a/locustfiles/go/locust-s3/main.go
+++ b/locustfiles/go/locust-s3/main.go
@@ -193,6 +193,7 @@ func deleteObject() {
 		time.Sleep(1000 * time.Millisecond)
 		return
 	}
+	time.Sleep(time.Duration(config.LoadConf.Locust.TimeDelay) * time.Millisecond)
 
 	start := time.Now().UnixNano() / config.LoadConf.Locust.TimeResolution
 	_, err := svc.DeleteObject(&s3.DeleteObjectInput{


### PR DESCRIPTION
Race condition if the same object get picked for GET and DELETE, and the DELETE occurs first the GET will fail. Configurable delay will reduce the Fail rate.